### PR TITLE
Fix mobile overflow: wrap inline code on continuous strings

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -115,9 +115,21 @@
     @apply bg-skin-card-muted;
   }
 
+  /* Inline code: wrap and break long continuous strings so they don't
+     overflow the viewport on mobile. */
   code {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+  /* Block code keeps its single-line layout with horizontal scroll. */
+  pre code {
     white-space: pre;
-    overflow: scroll;
+    overflow-wrap: normal;
+    word-break: normal;
+  }
+  pre {
+    overflow-x: auto;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Verdict
Mobile view broke because inline `<code>` could never wrap.

## Why
- `src/styles/base.css` had a global `code { white-space: pre; overflow: scroll }`.
- That rule applied to inline code too, so a continuous string like `opentelemetry/proto/{common,resource,metrics,trace,collector}/v1` blew past the viewport and forced horizontal scroll on the whole page.

## Fix
- Inline `code`: `white-space: pre-wrap` + `overflow-wrap: anywhere` + `word-break: break-word` so long continuous strings wrap.
- Block `pre code`: kept `white-space: pre` with `pre { overflow-x: auto }` so code blocks still scroll horizontally instead of mangling formatting.

```diff
-  code {
-    white-space: pre;
-    overflow: scroll;
-  }
+  code {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+  pre code {
+    white-space: pre;
+    overflow-wrap: normal;
+    word-break: normal;
+  }
+  pre {
+    overflow-x: auto;
+  }
```

## Standard
Separate concerns: inline code wraps, block code scrolls. Verified with `npm run build` (passes) and confirmed the rule lands in the compiled CSS.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b733926-7c7d-4d09-a929-d97e14c46359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b733926-7c7d-4d09-a929-d97e14c46359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

