### PR TITLE
Make mobile nav horizontal (drop hamburger menu)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -32,32 +32,7 @@ const { activeNav } = Astro.props;
         }
       </a>
       <nav id="nav-menu">
-        <button
-          class="hamburger-menu focus-outline"
-          aria-label="Open Menu"
-          aria-expanded="false"
-          aria-controls="menu-items"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            class="menu-icon"
-          >
-            <line x1="7" y1="12" x2="21" y2="12" class="line"></line>
-            <line x1="3" y1="6" x2="21" y2="6" class="line"></line>
-            <line x1="12" y1="18" x2="21" y2="18" class="line"></line>
-            <line x1="18" y1="6" x2="6" y2="18" class="close"></line>
-            <line x1="6" y1="6" x2="18" y2="18" class="close"></line>
-          </svg>
-        </button>
-        <ul id="menu-items" class="display-none sm:flex">
+        <ul id="menu-items">
           <li>
             <a href="/posts" class={activeNav === "posts" ? "active" : ""}>
               Posts
@@ -81,7 +56,7 @@ const { activeNav } = Astro.props;
           <li>
             <LinkButton
               href="/search"
-              className={`focus-outline p-3 sm:p-1 ${
+              className={`focus-outline p-2 sm:p-1 ${
                 activeNav === "search" ? "active" : ""
               }`}
               ariaLabel="search"
@@ -89,7 +64,7 @@ const { activeNav } = Astro.props;
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                class="scale-125 sm:scale-100"
+                class="scale-110 sm:scale-100"
                 ><path
                   d="M19.023 16.977a35.13 35.13 0 0 1-1.367-1.384c-.372-.378-.596-.653-.596-.653l-2.8-1.337A6.962 6.962 0 0 0 16 9c0-3.859-3.14-7-7-7S2 5.141 2 9s3.14 7 7 7c1.763 0 3.37-.66 4.603-1.739l1.337 2.8s.275.224.653.596c.387.363.896.854 1.384 1.367l1.358 1.392.604.646 2.121-2.121-.646-.604c-.379-.372-.885-.866-1.391-1.36zM9 14c-2.757 0-5-2.243-5-5s2.243-5 5-5 5 2.243 5 5-2.243 5-5 5z"
                 ></path>
@@ -131,36 +106,23 @@ const { activeNav } = Astro.props;
     @apply mx-auto flex max-w-3xl flex-col items-center justify-between sm:flex-row;
   }
   .top-nav-wrap {
-    @apply relative flex w-full items-start justify-between p-4 sm:items-center sm:py-8;
+    @apply relative flex w-full flex-col items-start gap-1 p-4 sm:flex-row sm:items-center sm:justify-between sm:gap-0 sm:py-8;
   }
   .logo {
-    @apply absolute py-1 text-xl font-semibold sm:static sm:text-2xl;
-  }
-  .hamburger-menu {
-    @apply self-end p-2 sm:hidden;
-  }
-  .hamburger-menu svg {
-    @apply h-6 w-6 scale-125 fill-skin-base;
+    @apply py-1 text-xl font-semibold sm:text-2xl;
   }
 
   nav {
-    @apply flex w-full flex-col items-center bg-skin-fill sm:ml-2 sm:flex-row sm:justify-end sm:space-x-4 sm:py-0;
+    @apply flex w-full flex-row flex-wrap items-center justify-center gap-x-1 gap-y-1 bg-skin-fill sm:ml-2 sm:w-auto sm:flex-nowrap sm:justify-end sm:gap-x-4;
   }
   nav ul {
-    @apply mt-4 grid w-44 grid-cols-2 grid-rows-5 gap-x-2 gap-y-2 sm:ml-0 sm:mt-0 sm:flex sm:w-auto sm:gap-x-5 sm:gap-y-0;
+    @apply flex flex-wrap items-center justify-center gap-x-1 gap-y-1 sm:flex-nowrap sm:gap-x-5;
   }
   nav ul li {
-    @apply col-span-2 flex items-center justify-center sm:col-span-1;
+    @apply flex items-center justify-center;
   }
   nav ul li a {
-    @apply w-full px-4 py-3 text-center font-medium hover:text-skin-accent sm:my-0 sm:px-2 sm:py-1;
-  }
-  nav ul li:nth-child(5) a {
-    @apply w-auto;
-  }
-  nav ul li:nth-child(5),
-  nav ul li:nth-child(6) {
-    @apply col-span-1;
+    @apply px-2 py-2 text-center font-medium hover:text-skin-accent sm:px-2 sm:py-1;
   }
   nav a.active {
     @apply underline decoration-wavy decoration-2 underline-offset-4;
@@ -176,40 +138,9 @@ const { activeNav } = Astro.props;
     @apply h-6 w-6 fill-skin-base hover:fill-skin-accent;
   }
   #theme-btn {
-    @apply p-3 sm:p-1;
+    @apply p-2 sm:p-1;
   }
   #theme-btn svg {
-    @apply scale-125 hover:rotate-12 sm:scale-100;
-  }
-
-  .menu-icon line {
-    @apply transition-opacity duration-75 ease-in-out;
-  }
-  .menu-icon .close {
-    opacity: 0;
-  }
-  .menu-icon.is-active .line {
-    @apply opacity-0;
-  }
-  .menu-icon.is-active .close {
-    @apply opacity-100;
+    @apply scale-110 hover:rotate-12 sm:scale-100;
   }
 </style>
-
-<script>
-  // Toggle menu
-  const menuBtn = document.querySelector(".hamburger-menu");
-  const menuIcon = document.querySelector(".menu-icon");
-  const menuItems = document.querySelector("#menu-items");
-
-  menuBtn?.addEventListener("click", () => {
-    const menuExpanded = menuBtn.getAttribute("aria-expanded") === "true";
-    menuIcon?.classList.toggle("is-active");
-    menuBtn.setAttribute("aria-expanded", menuExpanded ? "false" : "true");
-    menuBtn.setAttribute(
-      "aria-label",
-      menuExpanded ? "Open Menu" : "Close Menu"
-    );
-    menuItems?.classList.toggle("display-none");
-  });
-</script>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Verdict
Mobile nav now renders as a horizontal row instead of a hamburger toggle.

## Why
- `src/components/Header.astro` hid the menu behind `display-none sm:flex` and a JS-toggled hamburger, then laid the items out as a 2-col grid on mobile.
- Result: an extra tap to reach navigation and a vertical grid that looked nothing like the desktop bar.

## What changed
- Removed the hamburger button, its SVG, the toggle `<script>`, and the `.menu-icon`/grid CSS. Net `-80 / +11` lines.
- Menu items are always visible and laid out as a centered, wrapping flex row on mobile; unchanged `justify-end` row on desktop (`sm:`).
- Logo stacks on its own line above the nav on mobile (was absolutely positioned), static beside the nav on desktop.
- Trimmed icon/link padding and icon scale on mobile so all six items fit one row on common phone widths.

## Verification (headless Chrome against the build)
- 375px / 390px: logo on top, `Posts Tags About CV [search] [theme]` in one horizontal row.
- 320px (iPhone SE): gracefully wraps to two centered rows, still horizontal, no hamburger.
- post page: header horizontal, content intact.
- 900px: desktop layout unchanged (logo left, nav right).
- `npm run build` passes; built HTML no longer contains `hamburger` and `#menu-items` no longer carries `display-none`.

## Other mobile behaviours found
- Inline `<code>` with long continuous strings overflows the viewport (the original report). Fixed separately in #33 — not included here to keep PRs scoped.
- Markdown tables have no horizontal-scroll wrapper, so a wide table would overflow on mobile. No blog post currently uses one, so it's latent; left untouched. Easy follow-up: `.prose table { display:block; overflow-x:auto }`.

## Standard
Mobile and desktop should share one mental model; fewer taps to navigate; delete code over toggling it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b733926-7c7d-4d09-a929-d97e14c46359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b733926-7c7d-4d09-a929-d97e14c46359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

